### PR TITLE
replace f-str to format method & modified description &  rename the v…

### DIFF
--- a/1_what_is_API.ipynb
+++ b/1_what_is_API.ipynb
@@ -40,63 +40,69 @@
    "outputs": [],
    "source": [
     "# 執行此程式碼以檢視影片\n",
-    "from IPython.display import YouTubeVideo\n",
-    "YouTubeVideo('zvKadd9Cflc', width=1280/1.5, height=720/1.5)"
+    "from IPython.display import YouTubeVideo, HTML\n",
+    "YouTubeVideo(id='zvKadd9Cflc', width=1280/1.5, height=720/1.5)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "在 Python 程式碼中，要呼叫其他人的 API，最常見的做法是使用 Requests 套件去呼叫其他人的應用程式。\n",
+    "在 Python 程式碼中，要呼叫其他人的 API，最常見的做法是使用 Requests 套件去呼叫其他人的應用程式；並取得相應的回應(response)。\n",
     "\n",
     "如下方程式能取得現在的 IP。"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-12-24T08:59:02.978971Z",
-     "start_time": "2021-12-24T08:59:02.551611Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# 將此課程的驗證函式載入\n",
-    "from evaluator_script import evaluator_script\n",
-    "exec(evaluator_script)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-12-24T08:59:16.100254Z",
      "start_time": "2021-12-24T08:59:14.991796Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "My current IP is 118.165.3.33\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
-    "import requests\n",
-    "result = requests.get(\"https://ip.me\")\n",
-    "print(f\"My current IP is {result.text}\")"
+    "import requests \n",
+    "# rename to 'response' for matching the object name defined in request lib\n",
+    "response = requests.get(\"https://ip.me\")\n",
+    "# f-str syntax do not support below 3.6 ver or install backport of f-str ( future-fstrings )\n",
+    "print(\"My current IP is {}\".format(response.text))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-12-24T08:59:16.614515Z",
      "start_time": "2021-12-24T08:59:16.609281Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'118.165.3.33\\n'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "result.text"
+    "response.text"
    ]
   },
   {
@@ -105,7 +111,7 @@
    "source": [
     "你會注意到，這個 API 回傳的是純文字，\\\\n 的意思是換行。\n",
     "\n",
-    "但不是所有的 API 都是如此，大多數的 API 會使用 JSON 格式來進行溝通"
+    "但不是所有的 API 都是如此，大多數的 API 會使用 **JSON 格式** 來進行溝通。"
    ]
   },
   {
@@ -118,26 +124,37 @@
    },
    "source": [
     "## 1.1 JSON 格式\n",
-    "JSON (JavaScript Object Notation) 是一種輕量級資料交換格式。其內容由屬性和值所組成，因此也有易於閱讀和處理的優勢。\n",
+    "JSON (JavaScript Object Notation) 是一種輕量級*資料交換格式*。其內容由屬性和值所組成，因此也有易於閱讀和處理的優勢。\n",
     "\n",
     "JSON 是獨立於程式語言的資料格式，不僅是 JavaScript，各種語言都支援解析 JSON 格式的資料，因此 API 經常使用 JSON 格式來傳送資料。\n",
     "\n",
-    "下方的 API 能夠取得現在的時間，其回傳結果就是 JSON 格式"
+    "下方的 API 能夠取得現在的時間，並回傳JSON格式的結果，而我們仍能藉由`response.text`取得整體資訊的字串..."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-12-24T08:59:20.229699Z",
      "start_time": "2021-12-24T08:59:20.083158Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'{\"abbreviation\":\"CST\",\"client_ip\":\"118.165.3.33\",\"datetime\":\"2021-12-25T11:57:06.038064+08:00\",\"day_of_week\":6,\"day_of_year\":359,\"dst\":false,\"dst_from\":null,\"dst_offset\":0,\"dst_until\":null,\"raw_offset\":28800,\"timezone\":\"Asia/Taipei\",\"unixtime\":1640404626,\"utc_datetime\":\"2021-12-25T03:57:06.038064+00:00\",\"utc_offset\":\"+08:00\",\"week_number\":51}'"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "result = requests.get(\"http://worldtimeapi.org/api/timezone/Asia/Taipei\")\n",
-    "result.text"
+    "response = requests.get(\"http://worldtimeapi.org/api/timezone/Asia/Taipei\")\n",
+    "response.text"
    ]
   },
   {
@@ -172,18 +189,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-12-24T08:59:58.309722Z",
      "start_time": "2021-12-24T08:59:58.147558Z"
     }
    },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'abbreviation': 'GMT',\n",
+       " 'client_ip': '118.165.3.33',\n",
+       " 'datetime': '2021-12-25T03:57:14.517359+00:00',\n",
+       " 'day_of_week': 6,\n",
+       " 'day_of_year': 359,\n",
+       " 'dst': False,\n",
+       " 'dst_from': None,\n",
+       " 'dst_offset': 0,\n",
+       " 'dst_until': None,\n",
+       " 'raw_offset': 0,\n",
+       " 'timezone': 'Europe/London',\n",
+       " 'unixtime': 1640404634,\n",
+       " 'utc_datetime': '2021-12-25T03:57:14.517359+00:00',\n",
+       " 'utc_offset': '+00:00',\n",
+       " 'week_number': 51}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response = requests.get(\"http://worldtimeapi.org/api/timezone/Europe/London\")\n",
+    "london_time = response.json()\n",
+    "london_time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-12-24T08:59:02.978971Z",
+     "start_time": "2021-12-24T08:59:02.551611Z"
+    }
+   },
    "outputs": [],
    "source": [
-    "result = requests.get(\"http://worldtimeapi.org/api/timezone/Europe/London\")\n",
-    "london_time = result.json()\n",
-    "london_time"
+    "# 請於進行下面的測驗前執行此 cell，以將此課程的輔助函式載入\n",
+    "from evaluator_script import evaluator_script\n",
+    "exec(evaluator_script)"
    ]
   },
   {
@@ -196,14 +254,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-12-24T09:00:49.045877Z",
      "start_time": "2021-12-24T09:00:48.752713Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "測試失敗，請檢查變數 new_york_time 並且再試一次\n",
+      "你可以執行 hint 或 answer 來取得提示\n"
+     ]
+    }
+   ],
    "source": [
     "new_york_time = requests.get(\"http://worldtimeapi.org/api/timezone/Europe/London\").json()\n",
     "\n",
@@ -212,28 +279,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-12-24T09:00:50.974603Z",
      "start_time": "2021-12-24T09:00:50.967664Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "倫敦（London）是在歐洲（Europe），紐約（New_York）是在美洲（America）\n",
+      "想想看 \"http://worldtimeapi.org/api/timezone/Europe/London\" 這個網址，要怎麼改才會變成在美洲的紐約呢？\n"
+     ]
+    }
+   ],
    "source": [
     "hint_get_new_york_time()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-12-24T09:00:59.528599Z",
      "start_time": "2021-12-24T09:00:59.521492Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "#最佳做法\n",
+      "def get_new_york_time():\n",
+      "    return requests.get(\"http://worldtimeapi.org/api/timezone/America/New_York\").json()\n"
+     ]
+    }
+   ],
    "source": [
     "answer_get_new_york_time()"
    ]
@@ -243,44 +329,69 @@
    "metadata": {},
    "source": [
     "## 1.3 JSON 格式的轉換\n",
-    "要解讀 JSON 格式，你可以使用 `result.json()` 把資料解碼為 Python 的 `Dict` 格式"
+    "要解讀 JSON 格式，你可以使用 `response.json()` 把資料解碼為 Python 的 `Dict` 格式"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-12-24T09:01:01.008475Z",
      "start_time": "2021-12-24T09:01:00.996433Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'abbreviation': 'GMT', 'client_ip': '118.165.3.33', 'datetime': '2021-12-25T03:57:14.517359+00:00', 'day_of_week': 6, 'day_of_year': 359, 'dst': False, 'dst_from': None, 'dst_offset': 0, 'dst_until': None, 'raw_offset': 0, 'timezone': 'Europe/London', 'unixtime': 1640404634, 'utc_datetime': '2021-12-25T03:57:14.517359+00:00', 'utc_offset': '+00:00', 'week_number': 51}\n",
+      "\n",
+      " json 格式的 python 字典\n"
+     ]
+    }
+   ],
    "source": [
-    "result.json()"
+    "json_dict = response.json()\n",
+    "print(json_dict)\n",
+    "\n",
+    "isinstance(json_dict, dict) and print(\"\\n json 格式的 python 字典\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "或者是使用 `json` 函式庫來轉換文字格式的 JSON"
+    "或者是使用 `json` 函式庫將字串(str) 所描述的JSON格式轉換成python的字典"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-12-24T09:01:01.865501Z",
      "start_time": "2021-12-24T09:01:01.859055Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'abbreviation': 'GMT', 'client_ip': '118.165.3.33', 'datetime': '2021-12-25T03:57:14.517359+00:00', 'day_of_week': 6, 'day_of_year': 359, 'dst': False, 'dst_from': None, 'dst_offset': 0, 'dst_until': None, 'raw_offset': 0, 'timezone': 'Europe/London', 'unixtime': 1640404634, 'utc_datetime': '2021-12-25T03:57:14.517359+00:00', 'utc_offset': '+00:00', 'week_number': 51}\n",
+      "\n",
+      " json 格式的 python 字典\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
-    "json_data = json.loads(result.text)\n",
-    "json_data"
+    "json_dict = json.loads(response.text)\n",
+    "print(json_dict)\n",
+    "\n",
+    "isinstance(json_dict, dict) and print(\"\\n json 格式的 python 字典\")"
    ]
   },
   {
@@ -294,14 +405,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-12-24T09:01:02.472061Z",
      "start_time": "2021-12-24T09:01:02.462151Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'{\"abbreviation\": \"GMT\", \"client_ip\": \"118.165.3.33\", \"datetime\": \"2021-12-25T03:57:14.517359+00:00\", \"day_of_week\": 6, \"day_of_year\": 359, \"dst\": false, \"dst_from\": null, \"dst_offset\": 0, \"dst_until\": null, \"raw_offset\": 0, \"timezone\": \"Europe/London\", \"unixtime\": 1640404634, \"utc_datetime\": \"2021-12-25T03:57:14.517359+00:00\", \"utc_offset\": \"+00:00\", \"week_number\": 51}'"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "json_raw = json.dumps(json_data)\n",
     "json_raw"
@@ -374,7 +496,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.7.10"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Hello EasonC13, it's a great tutorial to introduce the application of 3-rd API for the beginner. The humble Pull-Request has been proposed here:
1. Replace f-str by calling the format method: f-str is a great way (less noise principle) to format the str. However, the f-str syntax has been proposed in python 3.6 and the version below 3.6 may cause the syntax error. The version requirement of python may be specific in README.md or req_lst.txt or let the user further install the other compatible package (e.g. future-fstrings).

2. Modified description: The description of the pynb is easy to read and additional information can be accessed by the given hyperlinks. There's almost not thing can be further improved.

3. Rename the var: The suggestion of renaming the variable 'results' has been proposed, because the request lib defined some object to describe the structure of return values. The variable name will be more suitable to match with the name of the request lib defined object. I just rename the 'results' by 'response' to present the response object, which has the text attribute, json method, ... etc. 